### PR TITLE
Fix gradle buildship using wrong JRE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,8 @@ apply plugin: 'java'
 apply plugin: 'maven'
 group = 'com.realityinteractive.imageio.tga'
 
+sourceCompatibility = 1.6
+
 buildscript {
 
     repositories {


### PR DESCRIPTION
In certain IDEs (like Eclipse), this will make sure Gradle uses the proper JRE library to build, and it documents targeted JRE compatibility. I set it to Java 6 because it seems like 5 is not supported by gradle anymore (will not compile on my machine).