### PR TITLE
Performance & Image format change

### DIFF
--- a/src/main/java/com/realityinteractive/imageio/tga/TGAImageReader.java
+++ b/src/main/java/com/realityinteractive/imageio/tga/TGAImageReader.java
@@ -158,7 +158,7 @@ public class TGAImageReader extends ImageReader
     /**
      * @see ImageReader#getImageTypes(int)
      */
-    public Iterator/*<ImageTypeSpecifier>*/ getImageTypes(final int imageIndex) 
+    public Iterator<ImageTypeSpecifier> getImageTypes(final int imageIndex) 
         throws IOException
     {
         // validate the imageIndex (this will throw if invalid)
@@ -210,7 +210,7 @@ public class TGAImageReader extends ImageReader
         }
 
         // create a list and add the ImageTypeSpecifier to it
-        final List/*<ImageTypeSpecifier>*/ imageSpecifiers = new ArrayList/*<ImageTypeSpecifier>*/();
+        final List<ImageTypeSpecifier> imageSpecifiers = new ArrayList<ImageTypeSpecifier>();
         imageSpecifiers.add(imageTypeSpecifier);
 
         return imageSpecifiers.iterator();
@@ -287,7 +287,7 @@ public class TGAImageReader extends ImageReader
     {
         // ensure that the image is of a supported type
         // NOTE:  this will implicitly ensure that the imageIndex is valid
-        final Iterator imageTypes = getImageTypes(imageIndex);
+        final Iterator<ImageTypeSpecifier> imageTypes = getImageTypes(imageIndex);
         if(!imageTypes.hasNext())
         {
             throw new IOException("Unsupported Image Type");

--- a/src/main/java/com/realityinteractive/imageio/tga/TGAImageReaderSpi.java
+++ b/src/main/java/com/realityinteractive/imageio/tga/TGAImageReaderSpi.java
@@ -131,7 +131,7 @@ public class TGAImageReaderSpi extends ImageReaderSpi
     {
         super(VENDOR_NAME, VERSION, FORMAT_NAMES, SUFFIXES, MIME_TYPES, 
               READER_CLASSNAME,
-              ImageReaderSpi.STANDARD_INPUT_TYPE,
+              new Class[]{ImageInputStream.class},
               WRITER_SPI_CLASSNAMES,
               SUPPORTS_STANDARD_STREAM_METADATA_FORMAT,
               NATIVE_STREAM_METADATA_FORMAT_NAME,

--- a/src/test/java/com/realityinteractive/imageio/tga/TGAImageReaderSpiTest.java
+++ b/src/test/java/com/realityinteractive/imageio/tga/TGAImageReaderSpiTest.java
@@ -2,14 +2,15 @@ package com.realityinteractive.imageio.tga;
 
 
 import org.junit.jupiter.api.Test;
-import sun.awt.image.IntegerInterleavedRaster;
+import sun.awt.image.ByteInterleavedRaster;
 
 import javax.imageio.ImageIO;
 import javax.imageio.spi.IIORegistry;
 import java.awt.image.BufferedImage;
-import java.awt.image.DirectColorModel;
+import java.awt.image.ComponentColorModel;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Arrays;
 
 class TGAImageReaderSpiTest {
 
@@ -33,13 +34,14 @@ class TGAImageReaderSpiTest {
 
         assert image.getType() == 4;
 
-        DirectColorModel color = (DirectColorModel) image.getColorModel();
-        assert color.getRedMask() == 0xff;
-        assert color.getGreenMask() == 0xff00;
-        assert color.getBlueMask() == 0xff0000;
-        assert color.getAlphaMask() == 0;
+        ComponentColorModel color = (ComponentColorModel) image.getColorModel();
+        assert color.getNumComponents() == 3;
+        assert color.getPixelSize() == 8;
+        assert Arrays.equals(color.getComponentSize(), new int[] {8, 8, 8});
+        assert color.hasAlpha() == false;
+        assert color.isAlphaPremultiplied() == false;
 
-        IntegerInterleavedRaster raster = (IntegerInterleavedRaster) image.getRaster();
+        ByteInterleavedRaster raster = (ByteInterleavedRaster) image.getRaster();
         assert raster.getWidth() == 1024;
         assert raster.getHeight() == 1024;
         assert raster.getNumBands() == 3;


### PR DESCRIPTION
Hey,

two things:

1. Performance
The `TGAImageReader` parser didn't buffer image data during reading. I gained a speedup of factor 40 on my machine by simply reading the pixel data with `readFully(..)` instead of `readByte()` or `readShort()` (~~since buffer inside `javax.imageio.stream.ImageInputStreamImpl` gets activated~~ Edit: I actually implemented a new buffer inside `ByteBuffer` in this PR) .

2. OpenCV
I recently tried to integrate JavaCV / OpenCV into my project. It's a native C++ library that has some nice & fast image functionality. When integrating it i noticed that the internal pixel format that the TGAImageReader creates is not optima for OpenCV, because if seems to expect BGR(A) `int`, but it gets RGB(A) `int`.  
Anyway, i changed the format to BGR(A) `byte[]` (interleaved instead of packed) which can be read by OpenCV. But i did not test these changes with non-24/32 bit per channel files, so if maybe sombody else could look over these changes maybe even test them that would be awesome.
If this second change is not desirable let me know.