### PR TITLE
JDK compatibility, Gradle upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 group = 'com.realityinteractive.imageio.tga'
 
-sourceCompatibility = 1.6
+sourceCompatibility = 1.7
 
 buildscript {
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip

--- a/src/main/java/com/realityinteractive/imageio/tga/TGAImageReader.java
+++ b/src/main/java/com/realityinteractive/imageio/tga/TGAImageReader.java
@@ -14,6 +14,7 @@ import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferByte;
 import java.awt.image.WritableRaster;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -380,7 +381,8 @@ public class TGAImageReader extends ImageReader
         final ByteBuffer inputBuffer = ByteBuffer.allocate(minBufferSize);
         inputBuffer.order(ByteOrder.LITTLE_ENDIAN);
         // Code that reads from buffer will check remaining limit and load more data if empty.
-        inputBuffer.limit(0);
+        // Cast is workaround for https://jira.mongodb.org/browse/JAVA-2559
+        ((Buffer)inputBuffer).limit(0);
 
         final byte[] packedPixelbuffer = new byte[4];
 
@@ -582,8 +584,9 @@ public class TGAImageReader extends ImageReader
             }
             if (bytesLoaded == -1)
                 return true;
-            buffer.position(0);
-            buffer.limit(remaining+bytesLoaded);
+            // cast is workaround for https://jira.mongodb.org/browse/JAVA-2559
+            ((Buffer)buffer).position(0);
+            ((Buffer)buffer).limit(remaining+bytesLoaded);
         }
         return false;
     }


### PR DESCRIPTION
This changes Java source version from 1.6 to 1.7 which means that a JDK 12 or newer (which dropped support for compiling Java 1.6 sources) can now be used to build / run Gradle.

This change ups Gradle version from 4.4.1 to 6.9.1 as well, which allows to choose a target runtime up to Java 15.

And this includes a quality of life fix for when you try to run this library on a target JDK that is higher than the target JDK specified in the Gradle file instead of changing the target in the Gradle file (this just means people don't run into problems even if they forget to adjust the target JDK version to their target before building).